### PR TITLE
Centralize module dependency versions in root POM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Spring Boot OpenAPI Generator
+
+This project is a Maven multi-module build for OpenAPI-related source generation.
+
+## Modules
+
+- **spring-boot-openapi-generator-generator**
+  - Depends on `com.squareup:javapoet`.
+  - Responsible for generating Java source files.
+  - No source implementation is added yet.
+
+- **spring-boot-openapi-generator-model-generation**
+  - Depends on `io.swagger.parser.v3:swagger-parser`.
+  - Responsible for generating a set of source files based on a set of JSON Schema definitions.
+  - No source implementation is added yet.
+
+- **spring-boot-openapi-generator-client-generation**
+  - Depends on `io.swagger.parser.v3:swagger-parser`.
+  - Responsible for generating a set of source files for a client based on schema/API definitions.
+  - No source implementation is added yet.
+
+- **spring-boot-openapi-generator-client-restclient**
+  - Placeholder module for RestClient-focused client generation/runtime support.
+
+- **spring-boot-openapi-generator-client-webclient**
+  - Placeholder module for WebClient-focused client generation/runtime support.
+
+## Dependency version management
+
+Dependency versions are managed centrally in the root `pom.xml` using the `<properties>` and `<dependencyManagement>` sections. Child modules declare dependencies without explicit versions.
+

--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <properties>
+        <javapoet.version>1.13.0</javapoet.version>
+        <swagger-parser.version>2.1.24</swagger-parser.version>
+    </properties>
+
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
@@ -16,7 +21,25 @@
     <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.squareup</groupId>
+                <artifactId>javapoet</artifactId>
+                <version>${javapoet.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger.parser.v3</groupId>
+                <artifactId>swagger-parser</artifactId>
+                <version>${swagger-parser.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <modules>
+        <module>spring-boot-openapi-generator-generator</module>
+        <module>spring-boot-openapi-generator-model-generation</module>
+        <module>spring-boot-openapi-generator-client-generation</module>
         <module>spring-boot-openapi-generator-client-restclient</module>
         <module>spring-boot-openapi-generator-client-webclient</module>
     </modules>

--- a/spring-boot-openapi-generator-client-generation/pom.xml
+++ b/spring-boot-openapi-generator-client-generation/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>spring-boot-openapi-generator-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>spring-boot-openapi-generator-client-generation</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/spring-boot-openapi-generator-generator/pom.xml
+++ b/spring-boot-openapi-generator-generator/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>spring-boot-openapi-generator-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>spring-boot-openapi-generator-generator</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.squareup</groupId>
+            <artifactId>javapoet</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/spring-boot-openapi-generator-model-generation/pom.xml
+++ b/spring-boot-openapi-generator-model-generation/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>spring-boot-openapi-generator-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>spring-boot-openapi-generator-model-generation</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser</artifactId>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
### Motivation

- Centralize dependency version declarations to make upgrades and maintenance easier across modules.
- Ensure child modules inherit versions from a single source of truth instead of declaring inline versions.

### Description

- Added `<properties>` in the root `pom.xml` for `javapoet.version` and `swagger-parser.version` and introduced a root `<dependencyManagement>` section that manages `com.squareup:javapoet` and `io.swagger.parser.v3:swagger-parser`.
- Updated module POMs (`spring-boot-openapi-generator-generator`, `spring-boot-openapi-generator-model-generation`, `spring-boot-openapi-generator-client-generation`) to remove explicit dependency versions so they inherit the versions from the parent `dependencyManagement`.
- Kept the multi-module layout in the parent `pom.xml` and documented centralized dependency version management in `README.md` under a new "Dependency version management" section.

### Testing

- Ran `mvn -q validate`, which could not complete because resolving `org.springframework.boot:spring-boot-starter-parent:4.0.2` from Maven Central returned HTTP 403 in this environment.
- No further automated build verification could be executed because the parent POM could not be fetched from the remote repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69884d36f29c8320808068e6cdf05e28)