### PR TITLE
Remove module name prefix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Build Validation
+
+Run `mvn compile` to compile the project.

--- a/client-restclient/pom.xml
+++ b/client-restclient/pom.xml
@@ -10,12 +10,5 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>spring-boot-openapi-generator-generator</artifactId>
-
-    <dependencies>
-        <dependency>
-            <groupId>com.squareup</groupId>
-            <artifactId>javapoet</artifactId>
-        </dependency>
-    </dependencies>
+    <artifactId>client-restclient</artifactId>
 </project>

--- a/client-webclient/pom.xml
+++ b/client-webclient/pom.xml
@@ -10,12 +10,5 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>spring-boot-openapi-generator-model-generation</artifactId>
-
-    <dependencies>
-        <dependency>
-            <groupId>io.swagger.parser.v3</groupId>
-            <artifactId>swagger-parser</artifactId>
-        </dependency>
-    </dependencies>
+    <artifactId>client-webclient</artifactId>
 </project>

--- a/generation-client/pom.xml
+++ b/generation-client/pom.xml
@@ -10,5 +10,12 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>spring-boot-openapi-generator-client-webclient</artifactId>
+    <artifactId>generation-client</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/generation-model/pom.xml
+++ b/generation-model/pom.xml
@@ -10,5 +10,12 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>spring-boot-openapi-generator-client-restclient</artifactId>
+    <artifactId>generation-model</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -10,12 +10,12 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>spring-boot-openapi-generator-client-generation</artifactId>
+    <artifactId>generator</artifactId>
 
     <dependencies>
         <dependency>
-            <groupId>io.swagger.parser.v3</groupId>
-            <artifactId>swagger-parser</artifactId>
+            <groupId>com.squareup</groupId>
+            <artifactId>javapoet</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -37,10 +37,10 @@
     </dependencyManagement>
 
     <modules>
-        <module>spring-boot-openapi-generator-generator</module>
-        <module>spring-boot-openapi-generator-model-generation</module>
-        <module>spring-boot-openapi-generator-client-generation</module>
-        <module>spring-boot-openapi-generator-client-restclient</module>
-        <module>spring-boot-openapi-generator-client-webclient</module>
+        <module>generator</module>
+        <module>generation-model</module>
+        <module>generation-client</module>
+        <module>client-restclient</module>
+        <module>client-webclient</module>
     </modules>
 </project>


### PR DESCRIPTION
## Summary
- Remove the verbose `spring-boot-openapi-generator-` prefix from all module directory names and artifact IDs
- Simplifies project structure: e.g. `spring-boot-openapi-generator-generator` → `generator`
- Add CLAUDE.md with build validation instruction

## Test plan
- [x] `mvn compile` passes successfully