### PR TITLE
Add RestClient CLI runner with OpenAPI parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+examples/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ This project is a Maven multi-module build for OpenAPI-related source generation
 - **spring-boot-openapi-generator-client-webclient**
   - Placeholder module for WebClient-focused client generation/runtime support.
 
+## Examples
+
+To download the example OpenAPI specs, run:
+
+```bash
+./scripts/download-examples.sh
+```
+
+This downloads the Petstore OpenAPI spec to `examples/petstore.json`.
+
 ## Dependency version management
 
 Dependency versions are managed centrally in the root `pom.xml` using the `<properties>` and `<dependencyManagement>` sections. Child modules declare dependencies without explicit versions.

--- a/client-restclient/pom.xml
+++ b/client-restclient/pom.xml
@@ -11,4 +11,24 @@
     </parent>
 
     <artifactId>client-restclient</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/client-restclient/src/main/java/com/example/restclient/RestClientGeneratorApplication.java
+++ b/client-restclient/src/main/java/com/example/restclient/RestClientGeneratorApplication.java
@@ -1,0 +1,38 @@
+package com.example.restclient;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class RestClientGeneratorApplication implements CommandLineRunner {
+
+    public static void main(String[] args) {
+        SpringApplication.run(RestClientGeneratorApplication.class, args);
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        if (args.length < 1) {
+            System.err.println("Usage: <openapi-spec-file>");
+            System.exit(1);
+        }
+
+        String specFile = args[0];
+        SwaggerParseResult result = new OpenAPIV3Parser().readLocation(specFile, null, null);
+        OpenAPI openAPI = result.getOpenAPI();
+
+        if (openAPI == null) {
+            System.err.println("Failed to parse OpenAPI spec: " + specFile);
+            if (result.getMessages() != null) {
+                result.getMessages().forEach(System.err::println);
+            }
+            System.exit(1);
+        }
+
+        System.out.println(openAPI);
+    }
+}

--- a/scripts/download-examples.sh
+++ b/scripts/download-examples.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+mkdir -p "$PROJECT_DIR/examples"
+curl -sL https://petstore3.swagger.io/api/v3/openapi.json -o "$PROJECT_DIR/examples/petstore.json"
+echo "Downloaded petstore.json to examples/petstore.json"

--- a/scripts/run-restclient-petstore.sh
+++ b/scripts/run-restclient-petstore.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+echo "Building client-restclient..."
+mvn -f "$PROJECT_DIR/pom.xml" -pl client-restclient -am package -q -DskipTests
+
+echo "Running client-restclient with petstore spec..."
+java -jar "$PROJECT_DIR/client-restclient/target/client-restclient-0.0.1-SNAPSHOT.jar" "$PROJECT_DIR/examples/petstore.json"


### PR DESCRIPTION
## Summary
- Make `client-restclient` a Spring Boot `CommandLineRunner` that takes an OpenAPI spec file path as a program argument and parses it using the Swagger parser
- Add `scripts/download-examples.sh` to download the Petstore OpenAPI spec to `examples/petstore.json`
- Add `scripts/run-restclient-petstore.sh` to build and run the application against the petstore spec
- Add `.gitignore` for `target/` and `examples/`

## Test plan
- [ ] Run `./scripts/download-examples.sh` and verify `examples/petstore.json` is downloaded
- [ ] Run `./scripts/run-restclient-petstore.sh` and verify the application starts, parses the spec, and prints the OpenAPI model
- [ ] Run `mvn compile` and verify the build succeeds