### PR TITLE
Add output path and package arguments to generator

### DIFF
--- a/client-restclient/src/main/java/com/example/restclient/RestClientGeneratorApplication.java
+++ b/client-restclient/src/main/java/com/example/restclient/RestClientGeneratorApplication.java
@@ -20,12 +20,16 @@ public class RestClientGeneratorApplication implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
-        if (args.length < 1) {
-            System.err.println("Usage: <openapi-spec-file>");
+        if (args.length < 3) {
+            System.err.println("Usage: <openapi-spec-file> <output-path> <output-package>");
             System.exit(1);
         }
 
         String specFile = args[0];
+        String outputPath = args[1];
+        String outputPackage = args[2];
+        String modelsPackage = outputPackage + ".models";
+
         SwaggerParseResult result = new OpenAPIV3Parser().readLocation(specFile, null, null);
         OpenAPI openAPI = result.getOpenAPI();
 
@@ -40,9 +44,11 @@ public class RestClientGeneratorApplication implements CommandLineRunner {
         ModelResolver modelResolver = new ModelResolver();
         List<ModelDescriptor> models = modelResolver.resolve(openAPI);
 
+        System.out.println("Output path: " + outputPath);
+        System.out.println("Models package: " + modelsPackage);
         System.out.println("Resolved " + models.size() + " model(s):");
         for (ModelDescriptor model : models) {
-            System.out.println("  " + model.name());
+            System.out.println("  " + modelsPackage + "." + model.name());
             for (var field : model.fields()) {
                 System.out.println("    - " + field.name() + ": " + field.type()
                         + (field.required() ? " (required)" : ""));

--- a/example-validation/petstore-validation/.gitignore
+++ b/example-validation/petstore-validation/.gitignore
@@ -1,0 +1,1 @@
+src/main/java/com/example/petstore/generated/

--- a/example-validation/petstore-validation/pom.xml
+++ b/example-validation/petstore-validation/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>example-validation-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>petstore-validation</artifactId>
+</project>

--- a/example-validation/pom.xml
+++ b/example-validation/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>example-validation-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>petstore-validation</module>
+    </modules>
+</project>

--- a/scripts/run-restclient-petstore.sh
+++ b/scripts/run-restclient-petstore.sh
@@ -8,4 +8,7 @@ echo "Building client-restclient..."
 mvn -f "$PROJECT_DIR/pom.xml" -pl client-restclient -am package -q -DskipTests
 
 echo "Running client-restclient with petstore spec..."
-java -jar "$PROJECT_DIR/client-restclient/target/client-restclient-0.0.1-SNAPSHOT.jar" "$PROJECT_DIR/examples/petstore.json"
+java -jar "$PROJECT_DIR/client-restclient/target/client-restclient-0.0.1-SNAPSHOT.jar" \
+  "$PROJECT_DIR/examples/petstore.json" \
+  "$PROJECT_DIR/example-validation/petstore-validation/src/main/java" \
+  "com.example.petstore.generated"


### PR DESCRIPTION
## Summary
- Add required `output-path` and `output-package` arguments to RestClientGeneratorApplication CLI
- Create `example-validation` multi-module Maven project with `petstore-validation` nested module
- Configure petstore-validation with `.gitignore` for generated sources (`src/main/java/com/example/petstore/generated/`)
- Update run script to pass new arguments with output directory and package configuration

## Test plan
- [x] Project compiles cleanly
- [x] Arguments are validated and usage message is clear
- [x] Models package is correctly derived as `output-package + ".models"`