### PR TITLE
Rename Maven groupId and package from com.example to nl.stijlaartit

### DIFF
--- a/client-restclient/pom.xml
+++ b/client-restclient/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.example</groupId>
+        <groupId>nl.stijlaartit</groupId>
         <artifactId>spring-boot-openapi-generator-parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
@@ -18,7 +18,7 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.example</groupId>
+            <groupId>nl.stijlaartit</groupId>
             <artifactId>generation-model</artifactId>
         </dependency>
         <dependency>

--- a/client-restclient/src/main/java/nl/stijlaartit/restclient/RestClientGeneratorApplication.java
+++ b/client-restclient/src/main/java/nl/stijlaartit/restclient/RestClientGeneratorApplication.java
@@ -1,7 +1,7 @@
-package com.example.restclient;
+package nl.stijlaartit.restclient;
 
-import com.example.generation.model.ModelResolver;
-import com.example.generator.model.ModelDescriptor;
+import nl.stijlaartit.generation.model.ModelResolver;
+import nl.stijlaartit.generator.model.ModelDescriptor;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.OpenAPIV3Parser;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;

--- a/client-webclient/pom.xml
+++ b/client-webclient/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.example</groupId>
+        <groupId>nl.stijlaartit</groupId>
         <artifactId>spring-boot-openapi-generator-parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>

--- a/example-validation/petstore-validation/pom.xml
+++ b/example-validation/petstore-validation/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.example</groupId>
+        <groupId>nl.stijlaartit</groupId>
         <artifactId>example-validation-parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>

--- a/example-validation/pom.xml
+++ b/example-validation/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.example</groupId>
+    <groupId>nl.stijlaartit</groupId>
     <artifactId>example-validation-parent</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>

--- a/generation-client/pom.xml
+++ b/generation-client/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.example</groupId>
+        <groupId>nl.stijlaartit</groupId>
         <artifactId>spring-boot-openapi-generator-parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>

--- a/generation-model/pom.xml
+++ b/generation-model/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.example</groupId>
+        <groupId>nl.stijlaartit</groupId>
         <artifactId>spring-boot-openapi-generator-parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
@@ -14,7 +14,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.example</groupId>
+            <groupId>nl.stijlaartit</groupId>
             <artifactId>generator</artifactId>
         </dependency>
         <dependency>

--- a/generation-model/src/main/java/nl/stijlaartit/generation/model/ModelResolver.java
+++ b/generation-model/src/main/java/nl/stijlaartit/generation/model/ModelResolver.java
@@ -1,8 +1,8 @@
-package com.example.generation.model;
+package nl.stijlaartit.generation.model;
 
-import com.example.generator.model.FieldDescriptor;
-import com.example.generator.model.ModelDescriptor;
-import com.example.generator.model.TypeDescriptor;
+import nl.stijlaartit.generator.model.FieldDescriptor;
+import nl.stijlaartit.generator.model.ModelDescriptor;
+import nl.stijlaartit.generator.model.TypeDescriptor;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Schema;
 

--- a/generation-model/src/main/java/nl/stijlaartit/generation/model/SchemaSignature.java
+++ b/generation-model/src/main/java/nl/stijlaartit/generation/model/SchemaSignature.java
@@ -1,4 +1,4 @@
-package com.example.generation.model;
+package nl.stijlaartit.generation.model;
 
 import io.swagger.v3.oas.models.media.Schema;
 

--- a/generation-model/src/test/java/nl/stijlaartit/generation/model/ModelResolverTest.java
+++ b/generation-model/src/test/java/nl/stijlaartit/generation/model/ModelResolverTest.java
@@ -1,8 +1,8 @@
-package com.example.generation.model;
+package nl.stijlaartit.generation.model;
 
-import com.example.generator.model.FieldDescriptor;
-import com.example.generator.model.ModelDescriptor;
-import com.example.generator.model.TypeDescriptor;
+import nl.stijlaartit.generator.model.FieldDescriptor;
+import nl.stijlaartit.generator.model.ModelDescriptor;
+import nl.stijlaartit.generator.model.TypeDescriptor;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.media.Schema;

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.example</groupId>
+        <groupId>nl.stijlaartit</groupId>
         <artifactId>spring-boot-openapi-generator-parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>

--- a/generator/src/main/java/nl/stijlaartit/generator/model/FieldDescriptor.java
+++ b/generator/src/main/java/nl/stijlaartit/generator/model/FieldDescriptor.java
@@ -1,4 +1,4 @@
-package com.example.generator.model;
+package nl.stijlaartit.generator.model;
 
 import java.util.Objects;
 

--- a/generator/src/main/java/nl/stijlaartit/generator/model/ModelDescriptor.java
+++ b/generator/src/main/java/nl/stijlaartit/generator/model/ModelDescriptor.java
@@ -1,4 +1,4 @@
-package com.example.generator.model;
+package nl.stijlaartit.generator.model;
 
 import java.util.List;
 import java.util.Objects;

--- a/generator/src/main/java/nl/stijlaartit/generator/model/TypeDescriptor.java
+++ b/generator/src/main/java/nl/stijlaartit/generator/model/TypeDescriptor.java
@@ -1,4 +1,4 @@
-package com.example.generator.model;
+package nl.stijlaartit.generator.model;
 
 import java.util.Objects;
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <relativePath/>
     </parent>
 
-    <groupId>com.example</groupId>
+    <groupId>nl.stijlaartit</groupId>
     <artifactId>spring-boot-openapi-generator-parent</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
@@ -34,12 +34,12 @@
                 <version>${swagger-parser.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.example</groupId>
+                <groupId>nl.stijlaartit</groupId>
                 <artifactId>generator</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.example</groupId>
+                <groupId>nl.stijlaartit</groupId>
                 <artifactId>generation-model</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/scripts/run-restclient-petstore.sh
+++ b/scripts/run-restclient-petstore.sh
@@ -11,4 +11,4 @@ echo "Running client-restclient with petstore spec..."
 java -jar "$PROJECT_DIR/client-restclient/target/client-restclient-0.0.1-SNAPSHOT.jar" \
   "$PROJECT_DIR/examples/petstore.json" \
   "$PROJECT_DIR/example-validation/petstore-validation/src/main/java" \
-  "com.example.petstore.generated"
+  "nl.stijlaartit.petstore.generated"


### PR DESCRIPTION
## Summary
Renames the Maven groupId from `com.example` to `nl.stijlaartit` across all modules and updates all Java package declarations and imports accordingly. Includes both main project modules and the validation module.

## Changes
- Updated all 8 pom.xml files with new groupId
- Moved Java source files from `com/example/` to `nl/stijlaartit/` directory structure
- Updated all package declarations and imports in Java files
- Updated build script to reference new package name

## Test plan
- ✅ Project compiles successfully with `mvn compile`
- ✅ No remaining references to `com.example` in codebase
- ✅ Directory structure matches new package naming