### PR TITLE
Improve integration tests on example-validation projects

### DIFF
--- a/example-validation/petstore-validation-maven-plugin/pom.xml
+++ b/example-validation/petstore-validation-maven-plugin/pom.xml
@@ -15,6 +15,10 @@
     <artifactId>petstore-validation-maven-plugin</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 
+    <properties>
+        <mockwebserver.version>5.3.2</mockwebserver.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -33,6 +37,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>${mockwebserver.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/example-validation/petstore-validation-maven-plugin/src/test/java/nl/stijlaartit/petstore/generated/IntegrationTest.java
+++ b/example-validation/petstore-validation-maven-plugin/src/test/java/nl/stijlaartit/petstore/generated/IntegrationTest.java
@@ -1,24 +1,32 @@
 package nl.stijlaartit.petstore.generated;
 
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import nl.stijlaartit.petstore.generated.client.PetApi;
 import nl.stijlaartit.petstore.generated.client.StoreApi;
 import nl.stijlaartit.petstore.generated.client.UserApi;
 import nl.stijlaartit.petstore.generated.models.Category;
 import nl.stijlaartit.petstore.generated.models.Pet;
 import nl.stijlaartit.petstore.generated.models.PetStatus;
+import nl.stijlaartit.petstore.generated.models.Tag;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.web.client.ResourceAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 public class IntegrationTest {
+
+    private static MockWebServer server;
 
     @Autowired
     private PetApi petApi;
@@ -26,6 +34,18 @@ public class IntegrationTest {
     private StoreApi storeApi;
     @Autowired
     private UserApi userApi;
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        server = new MockWebServer();
+        server.start();
+        System.setProperty("mockserver.url", "http://" + server.getHostName() + ":" + server.getPort());
+    }
+
+    @AfterAll
+    static void afterAll() {
+        server.close();
+    }
 
     @Test
     void shouldBuildApis() {
@@ -36,10 +56,43 @@ public class IntegrationTest {
     }
 
     @Test
-    void shouldMakeACall() {
+    void shouldMakeACall() throws InterruptedException {
+        server.enqueue(new MockResponse.Builder()
+                .addHeader("Content-Type", "application/json")
+                .body("{\"id\": 10, \"name\": \"Doggo\", \"category\": {\"id\": 1, \"name\": \"Dogs\"}, \"photoUrls\": [\"http://example.com/photo1.jpg\"], \"tags\": [{\"id\": 0, \"name\": \"friendly\"}], \"status\": \"available\"}")
+                .build());
+
         Pet newPet = new Pet(null, "Name", new Category(1L, "Name"), List.of(), List.of(), PetStatus.AVAILABLE);
-        ResourceAccessException failure = assertThrows(ResourceAccessException.class, () -> petApi.addPet(newPet));
-        assertThat(failure.getMessage())
-                .startsWith("I/O error on POST request for \"http://localhost:7777/pet\":");
+        Pet createdPet = petApi.addPet(newPet);
+
+        assertThat(createdPet).isEqualTo(new Pet(10L, "Doggo", new Category(1L, "Dogs"),
+                List.of("http://example.com/photo1.jpg"), List.of(new Tag(0L, "friendly")), PetStatus.AVAILABLE));
+
+        final var request = server.takeRequest();
+        assertThat(request.getMethod()).isEqualTo("POST");
+        assertThat(request.getHeaders().get("Content-Type")).isEqualTo("application/json");
+        assertThat(request.getUrl().encodedPath()).isEqualTo("/pet");
+        assertThat(request.getBody().utf8()).isEqualTo("{\"name\":\"Name\",\"category\":{\"id\":1,\"name\":\"Name\"},\"photoUrls\":[],\"tags\":[],\"status\":\"available\"}");
+    }
+
+    @Test
+    void shouldMakeACallResponseEntity() throws InterruptedException {
+        server.enqueue(new MockResponse.Builder()
+                .addHeader("Content-Type", "application/json")
+                .body("{\"id\": 10, \"name\": \"Doggo\", \"category\": {\"id\": 1, \"name\": \"Dogs\"}, \"photoUrls\": [\"http://example.com/photo1.jpg\"], \"tags\": [{\"id\": 0, \"name\": \"friendly\"}], \"status\": \"available\"}")
+                .build());
+
+        Pet newPet = new Pet(null, "Name", new Category(1L, "Name"), List.of(), List.of(), PetStatus.AVAILABLE);
+        ResponseEntity<Pet> response = petApi.addPetResponseEntity(newPet);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(new Pet(10L, "Doggo", new Category(1L, "Dogs"),
+                List.of("http://example.com/photo1.jpg"), List.of(new Tag(0L, "friendly")), PetStatus.AVAILABLE));
+
+        final var request = server.takeRequest();
+        assertThat(request.getMethod()).isEqualTo("POST");
+        assertThat(request.getHeaders().get("Content-Type")).isEqualTo("application/json");
+        assertThat(request.getUrl().encodedPath()).isEqualTo("/pet");
+        assertThat(request.getBody().utf8()).isEqualTo("{\"name\":\"Name\",\"category\":{\"id\":1,\"name\":\"Name\"},\"photoUrls\":[],\"tags\":[],\"status\":\"available\"}");
     }
 }

--- a/example-validation/petstore-validation-maven-plugin/src/test/java/nl/stijlaartit/petstore/generated/IntegrationTestApplication.java
+++ b/example-validation/petstore-validation-maven-plugin/src/test/java/nl/stijlaartit/petstore/generated/IntegrationTestApplication.java
@@ -20,7 +20,8 @@ public class IntegrationTestApplication {
 
     @Bean
     HttpServiceProxyFactory httpServiceProxyFactory() {
-        RestClient restClient = RestClient.create("http://localhost:7777");
+        String url = System.getProperty("mockserver.url");
+        RestClient restClient = RestClient.create(url);
         RestClientAdapter adapter = RestClientAdapter.create(restClient);
         return HttpServiceProxyFactory.builderFor(adapter).build();
     }

--- a/example-validation/realworld-validation/pom.xml
+++ b/example-validation/realworld-validation/pom.xml
@@ -15,6 +15,10 @@
     <artifactId>realworld-validation</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 
+    <properties>
+        <mockwebserver.version>5.3.2</mockwebserver.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -33,6 +37,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>${mockwebserver.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/example-validation/realworld-validation/src/test/java/nl/stijlaartit/realworld/generated/IntegrationTest.java
+++ b/example-validation/realworld-validation/src/test/java/nl/stijlaartit/realworld/generated/IntegrationTest.java
@@ -1,25 +1,30 @@
 package nl.stijlaartit.realworld.generated;
 
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import nl.stijlaartit.realworld.generated.client.ArticlesApi;
 import nl.stijlaartit.realworld.generated.client.CommentsApi;
 import nl.stijlaartit.realworld.generated.client.FavoritesApi;
 import nl.stijlaartit.realworld.generated.client.ProfileApi;
 import nl.stijlaartit.realworld.generated.client.TagsApi;
 import nl.stijlaartit.realworld.generated.client.UserAndAuthenticationApi;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import nl.stijlaartit.realworld.generated.models.UpdateCurrentUserRequest;
 import nl.stijlaartit.realworld.generated.models.UpdateUser;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.web.client.ResourceAccessException;
 
+import java.io.IOException;
 import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 public class IntegrationTest {
+
+    private static MockWebServer server;
 
     @Autowired
     private ArticlesApi articlesApi;
@@ -34,6 +39,18 @@ public class IntegrationTest {
     @Autowired
     private UserAndAuthenticationApi userAndAuthenticationApi;
 
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        server = new MockWebServer();
+        server.start();
+        System.setProperty("mockserver.url", "http://" + server.getHostName() + ":" + server.getPort());
+    }
+
+    @AfterAll
+    static void afterAll() {
+        server.close();
+    }
+
     @Test
     void shouldBuildApis() {
         Objects.requireNonNull(articlesApi);
@@ -45,21 +62,40 @@ public class IntegrationTest {
     }
 
     @Test
-    void shouldMakeACall() {
-        ResourceAccessException failure = assertThrows(ResourceAccessException.class, tagsApi::getTags);
-        assertThat(failure.getMessage())
-                .startsWith("I/O error on GET request for \"http://localhost:7777/tags\":");
+    void shouldMakeACall() throws InterruptedException {
+        server.enqueue(new MockResponse.Builder()
+                .addHeader("Content-Type", "application/json")
+                .body("{\"tags\":[\"spring\",\"java\"]}")
+                .build());
+
+        Object response = tagsApi.getTags();
+        assertThat(response).isNotNull();
+
+        final var request = server.takeRequest();
+        assertThat(request.getMethod()).isEqualTo("GET");
+        assertThat(request.getUrl().encodedPath()).isEqualTo("/tags");
     }
 
     @Test
-    void shouldResolveTypesFromRequestBodyRefs() {
+    void shouldResolveTypesFromRequestBodyRefs() throws InterruptedException {
+        server.enqueue(new MockResponse.Builder()
+                .addHeader("Content-Type", "application/json")
+                .body("{\"user\":{\"email\":\"jane@example.com\",\"token\":\"jwt-token\",\"username\":\"jane\",\"bio\":null,\"image\":null}}")
+                .build());
+
         // Validates that request body is accepted
         UpdateCurrentUserRequest payload = UpdateCurrentUserRequest.builder()
                 .user(UpdateUser.builder()
                         .build())
                 .build();
-        ResourceAccessException failure = assertThrows(ResourceAccessException.class, () -> userAndAuthenticationApi.updateCurrentUser(payload));
-        assertThat(failure.getMessage())
-                .startsWith("I/O error on PUT request for \"http://localhost:7777/user\":");
+
+        Object response = userAndAuthenticationApi.updateCurrentUser(payload);
+        assertThat(response).isNotNull();
+
+        final var request = server.takeRequest();
+        assertThat(request.getMethod()).isEqualTo("PUT");
+        assertThat(request.getHeaders().get("Content-Type")).isEqualTo("application/json");
+        assertThat(request.getUrl().encodedPath()).isEqualTo("/user");
+        assertThat(request.getBody().utf8()).isEqualTo("{\"user\":{}}");
     }
 }

--- a/example-validation/realworld-validation/src/test/java/nl/stijlaartit/realworld/generated/IntegrationTestApplication.java
+++ b/example-validation/realworld-validation/src/test/java/nl/stijlaartit/realworld/generated/IntegrationTestApplication.java
@@ -22,7 +22,8 @@ public class IntegrationTestApplication {
 
     @Bean
     HttpServiceProxyFactory httpServiceProxyFactory() {
-        RestClient restClient = RestClient.create("http://localhost:7777");
+        String url = System.getProperty("mockserver.url");
+        RestClient restClient = RestClient.create(url);
         RestClientAdapter adapter = RestClientAdapter.create(restClient);
         return HttpServiceProxyFactory.builderFor(adapter).build();
     }


### PR DESCRIPTION
## Summary
- replace integration tests that asserted `ResourceAccessException` with `MockWebServer`-backed request/response assertions
- wire test `RestClient` base URL via `mockserver.url` in `petstore-validation-maven-plugin` and `realworld-validation`
- add `mockwebserver` test dependency to both affected modules

## Verification
- `./scripts/verify.sh`

Closes #28